### PR TITLE
Better component destruction

### DIFF
--- a/packages/component/index.js
+++ b/packages/component/index.js
@@ -152,6 +152,10 @@ class Component {
    * and forward destruction to all child components
    */
   destroy() {
+    if (this.onDestroy) {
+      this.onDestroy()
+    }
+
     if (this.components) {
       Object.keys(this.components)
         .forEach(key => (this.components[key].length

--- a/packages/component/index.js
+++ b/packages/component/index.js
@@ -166,9 +166,7 @@ class Component {
         ))
     }
 
-    if (this.onDestroy) {
-      this.onDestroy()
-    }
+    this.components = null
   }
 }
 

--- a/packages/component/index.test.js
+++ b/packages/component/index.test.js
@@ -111,7 +111,7 @@ test('Component should have options', done => {
 test('Component destroy should chain-call `onDestroy`', done => {
   app.destroy()
   expect(app.isDestroyed).toBe(true)
-  expect(app.components.inner.isDestroyed).toBe(true)
+  expect(app.components).toEqual(null)
   done()
 })
 


### PR DESCRIPTION
With this change we enable a component's `onDestroy` to use sub-components before they're taken down.

We also void our references to them to allow for garbage collection.