### PR TITLE
Changed matcher in isChildOf in Readme and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Can be extended or instantiated
 #### [dom](https://github.com/okiba-gang/okiba/tree/master/packages/dom)
 Utilities to work with dom elements and selectors
 
-###### [`byId`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#byidid), [`qs`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#qsselector-element), [`qsa`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#qsaselector-element), [`on`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#onwindow-type-handler), [`off`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#offwindow-type-handler), [`eventCoords`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#eventcoordsDOM), [`offset`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#offsetel), [`getElements`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#getelementstarget), [`matcher`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#matcherel-target), [`delegate`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#delegatetarget-event-callback-options)
+###### [`byId`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#byidid), [`qs`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#qsselector-element), [`qsa`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#qsaselector-element), [`on`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#onwindow-type-handler), [`off`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#offwindow-type-handler), [`eventCoords`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#eventcoordsDOM), [`offset`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#offsetel), [`getElements`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#getelementstarget), [`isChildOf`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#isChildOfel-target), [`delegate`](https://github.com/okiba-gang/okiba/tree/master/packages/dom#delegatetarget-event-callback-options)
 ---
 
 #### [drag-emitter](https://github.com/okiba-gang/okiba/tree/master/packages/drag-emitter)
@@ -102,7 +102,7 @@ Emits drag events for all common pointers kinds (touch & mouse)
 #### [easings](https://github.com/okiba-gang/okiba/tree/master/packages/easings)
 Collection of easings to alter a value
 
-###### 
+######
 ---
 
 #### [event-emitter](https://github.com/okiba-gang/okiba/tree/master/packages/event-emitter)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "docs": "node ./docs/generate.js",
     "version": "npm run build && npm run docs"
   },
+  "engines": {
+    "node": ">=10.17.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/plugin-proposal-class-properties": "^7.5.5",

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -8,7 +8,7 @@ Utilities to work with dom elements and selectors
 
 ### Installation
 
-You can grab it as an `npm` package 
+You can grab it as an `npm` package
 ```bash
 npm i --save @okiba/dom
 ```
@@ -346,10 +346,10 @@ The target you want to be sure to obtain as an array of Elements
 #### Returns
 
 `Array.<Element>` An array of Elements
-## matcher(el, target)
+## isChildOf(el, target)
 
 
-Checks if the given elemens has an ancestor which matches a selector
+Checks if the given element has an ancestor which matches a selector
 
 
 
@@ -357,13 +357,17 @@ Checks if the given elemens has an ancestor which matches a selector
 
 
 ```javascript
-import {delegate} from '@okiba/dom'
+/**
+ * <div id="ancestor">
+ *    <div id="el"></div>
+ * </div>
+*/
 
-const undelegate = delegate('a.internal-navigation', 'click', onNavigationClick, {capture: true})
+import {byId, isChildOf} from '@okiba/dom'
 
-function disableNavigation() {
-  undelegate()
-}
+const gotAncestor = isChildOf(byId('el'), '#ancestor')
+
+console.log(gotAncestor) // true
 ```
 
 

--- a/packages/dom/index.js
+++ b/packages/dom/index.js
@@ -246,16 +246,17 @@ function getMatcher() {
 }
 
 /**
- * Checks if the given elemens has an ancestor which matches a selector
+ * Checks if the given element has an ancestor which matches a selector
  *
  * @example
- * import {delegate} from '@okiba/dom'
+ * <div id="ancestor">
+ *    <div id="el"></div>
+ * </div>
  *
- * const undelegate = delegate('a.internal-navigation', 'click', onNavigationClick, {capture: true})
+ * import {byId, isChildOf} from '@okiba/dom'
  *
- * function disableNavigation() {
- *   undelegate()
- * }
+ * const gotAncestor = isChildOf(byId('el'), '#ancestor')
+ * console.log(gotAncestor) // true
  *
  * @param {Element} el Element to check
  * @param {(String|Element)} target Selector to match


### PR DESCRIPTION
The matcher method has been updated in isChildOf for these reasons:

- In the `packages/dom/index.js` matcher method is not defined, it is defined and exported the method `isChildOf`
- The matcher example was related to the `delegate` method.